### PR TITLE
Protect emails

### DIFF
--- a/content/authors/ahmedallam/_index.md
+++ b/content/authors/ahmedallam/_index.md
@@ -34,12 +34,11 @@ interests:
 
 # Social/Academic Networking
 # For available icons, see: https://sourcethemes.com/academic/docs/page-builder/#icons
-#   For an email link, use "fas" icon pack, "envelope" icon, and a link in the
-#   form "mailto:your-email@example.com" or "#contact" for contact widget.
+#   For an email link, use "fas" icon pack, "envelope" icon, and your uzh email up to before the '@'.
 social:
 - icon: envelope
   icon_pack: fas
-  link: "mailto:ahmed.allam@uzh.ch"
+  link: "ahmed.allam"
 #- icon: github
 #  icon_pack: fab
 #  link: https://github.com/lokijuhy

--- a/content/authors/annasintsova/_index.md
+++ b/content/authors/annasintsova/_index.md
@@ -35,12 +35,11 @@ interests:
 
 # Social/Academic Networking
 # For available icons, see: https://sourcethemes.com/academic/docs/page-builder/#icons
-#   For an email link, use "fas" icon pack, "envelope" icon, and a link in the
-#   form "mailto:your-email@example.com" or "#contact" for contact widget.
+#   For an email link, use "fas" icon pack, "envelope" icon, and your uzh email up to before the '@'.
 social:
 - icon: envelope
   icon_pack: fas
-  link: "mailto:anna.sintsova@uzh.ch"
+  link: "anna.sintsova"
 # - icon: github
 #   icon_pack: fab
 #   link: https://github.com/lokijuhy

--- a/content/authors/claudiastenger/_index.md
+++ b/content/authors/claudiastenger/_index.md
@@ -34,12 +34,11 @@ organizations:
 
 # Social/Academic Networking
 # For available icons, see: https://sourcethemes.com/academic/docs/page-builder/#icons
-#   For an email link, use "fas" icon pack, "envelope" icon, and a link in the
-#   form "mailto:your-email@example.com" or "#contact" for contact widget.
+#   For an email link, use "fas" icon pack, "envelope" icon, and your uzh email up to before the '@'.
 social:
 - icon: envelope
   icon_pack: fas
-  link: "mailto:claudia.stenger-gysling@uzh.ch"
+  link: "claudia.stenger-gysling"
 # Link to a PDF of your resume/CV from the About widget.
 # To enable, copy your resume/CV to `static/files/cv.pdf` and uncomment the lines below.
 # - icon: cv

--- a/content/authors/kyriakosschwarz/_index.md
+++ b/content/authors/kyriakosschwarz/_index.md
@@ -36,12 +36,11 @@ education:
 
 # Social/Academic Networking
 # For available icons, see: https://sourcethemes.com/academic/docs/page-builder/#icons
-#   For an email link, use "fas" icon pack, "envelope" icon, and a link in the
-#   form "mailto:your-email@example.com" or "#contact" for contact widget.
+#   For an email link, use "fas" icon pack, "envelope" icon, and your uzh email up to before the '@'.
 social:
 - icon: envelope
   icon_pack: fas
-  link: "mailto:kyriakos.schwarz@uzh.ch"
+  link: "kyriakos.schwarz"
 # - icon: github
 #   icon_pack: fab
 #   link: https://github.com/lokijuhy

--- a/content/authors/laurakinkead/_index.md
+++ b/content/authors/laurakinkead/_index.md
@@ -39,8 +39,10 @@ education:
 social:
 - icon: envelope
   icon_pack: fas
+  link: "<A HREF="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email to TEST</A>"
 #  link: "mailto:laura.kinkead@uzh.ch"
-   link: "<A HREF="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email to TEST</A>"
+
+
 # - icon: github
 #   icon_pack: fab
 #   link: https://github.com/lokijuhy

--- a/content/authors/laurakinkead/_index.md
+++ b/content/authors/laurakinkead/_index.md
@@ -39,8 +39,7 @@ education:
 social:
 - icon: envelope
   icon_pack: fas
-  link: "<A HREF="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email to TEST</A>"
-#  link: "mailto:laura.kinkead@uzh.ch"
+  link: "laura.kinkead@uzh.ch"
 
 
 # - icon: github

--- a/content/authors/laurakinkead/_index.md
+++ b/content/authors/laurakinkead/_index.md
@@ -39,10 +39,11 @@ education:
 social:
 - icon: envelope
   icon_pack: fas
-  link: "mailto:laura.kinkead@uzh.ch"
-- icon: github
-  icon_pack: fab
-  link: https://github.com/lokijuhy
+#  link: "mailto:laura.kinkead@uzh.ch"
+   link: "<A HREF="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email to {{member.name}}</A>"
+# - icon: github
+#   icon_pack: fab
+#   link: https://github.com/lokijuhy
 # Link to a PDF of your resume/CV from the About widget.
 # To enable, copy your resume/CV to `static/files/cv.pdf` and uncomment the lines below.
 # - icon: cv

--- a/content/authors/laurakinkead/_index.md
+++ b/content/authors/laurakinkead/_index.md
@@ -40,7 +40,7 @@ social:
 - icon: envelope
   icon_pack: fas
 #  link: "mailto:laura.kinkead@uzh.ch"
-   link: "<A HREF="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email to {{member.name}}</A>"
+   link: "<A HREF="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email to TEST</A>"
 # - icon: github
 #   icon_pack: fab
 #   link: https://github.com/lokijuhy

--- a/content/authors/laurakinkead/_index.md
+++ b/content/authors/laurakinkead/_index.md
@@ -34,12 +34,11 @@ education:
 
 # Social/Academic Networking
 # For available icons, see: https://sourcethemes.com/academic/docs/page-builder/#icons
-#   For an email link, use "fas" icon pack, "envelope" icon, and a link in the
-#   form "mailto:your-email@example.com" or "#contact" for contact widget.
+#   For an email link, use "fas" icon pack, "envelope" icon, and your uzh email up to before the '@'.
 social:
 - icon: envelope
   icon_pack: fas
-  link: "laura.kinkead@uzh.ch"
+  link: "laura.kinkead"
 
 
 # - icon: github

--- a/content/authors/matthiasdittberner/_index.md
+++ b/content/authors/matthiasdittberner/_index.md
@@ -35,12 +35,11 @@ interests:
 
 # Social/Academic Networking
 # For available icons, see: https://sourcethemes.com/academic/docs/page-builder/#icons
-#   For an email link, use "fas" icon pack, "envelope" icon, and a link in the
-#   form "mailto:your-email@example.com" or "#contact" for contact widget.
+#   For an email link, use "fas" icon pack, "envelope" icon, and your uzh email up to before the '@'.
 social:
 - icon: envelope
   icon_pack: fas
-  link: "mailto:matthias.dittberner@uzh.ch"
+  link: "matthias.dittberner"
 # - icon: github
 #   icon_pack: fab
 #   link: https://github.com/lokijuhy

--- a/content/authors/michaelkrauthammer/_index.md
+++ b/content/authors/michaelkrauthammer/_index.md
@@ -36,12 +36,11 @@ education:
 
 # Social/Academic Networking
 # For available icons, see: https://sourcethemes.com/academic/docs/page-builder/#icons
-#   For an email link, use "fas" icon pack, "envelope" icon, and a link in the
-#   form "mailto:your-email@example.com" or "#contact" for contact widget.
+#   For an email link, use "fas" icon pack, "envelope" icon, and your uzh email up to before the '@'.
 social:
 - icon: envelope
   icon_pack: fas
-  link: "mailto:michael.krauthammer@uzh.ch"
+  link: "michael.krauthammer"
 
 # Link to a PDF of your resume/CV from the About widget.
 # To enable, copy your resume/CV to `static/files/cv.pdf` and uncomment the lines below.

--- a/content/authors/nicoperez/_index.md
+++ b/content/authors/nicoperez/_index.md
@@ -39,12 +39,11 @@ education:
 
 # Social/Academic Networking
 # For available icons, see: https://sourcethemes.com/academic/docs/page-builder/#icons
-#   For an email link, use "fas" icon pack, "envelope" icon, and a link in the
-#   form "mailto:your-email@example.com" or "#contact" for contact widget.
+#   For an email link, use "fas" icon pack, "envelope" icon, and your uzh email up to before the '@'.
 social:
 - icon: envelope
   icon_pack: fas
-  link: "mailto:nicolas.perezgonzalez@uzh.ch"
+  link: "nicolas.perezgonzalez"
 # - icon: github
 #   icon_pack: fab
 #   link: https://github.com/lokijuhy

--- a/content/authors/zsoltbalazs/_index.md
+++ b/content/authors/zsoltbalazs/_index.md
@@ -42,7 +42,7 @@ education:
 social:
 - icon: envelope
   icon_pack: fas
-  link: "mailto:zsolt.balazs@uzh.ch"
+  link: "zsolt.balazs"
 - icon: github
   icon_pack: fab
   link: https://github.com/zsolt-balazs

--- a/content/home/contact.md
+++ b/content/home/contact.md
@@ -31,7 +31,11 @@ email_form = 0
           <p class="institution">Schmelzbergstrasse 26</p>
           <p class="institution">8006 Zürich</p>
           <p class="institution">Building/Room: SHM 26 A2</p>
-          <p class="institution"><a href="mailto:michael.krauthammer@uzh.ch"><i class="fas fa-envelope"></i></a></p>
+          <p class="institution">
+            <a href="#" onclick="u='michael.krauthammer'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">
+              <i class="fas fa-envelope"></i>
+             </a>
+          </p>
         </div>
       </li>
     </ul>
@@ -48,7 +52,11 @@ email_form = 0
           <p class="institution">CH-8057 Zürich</p>
           <p class="institution">Building/Room: Y32-F-01</p>
           <p class="institution">phone: +41 44 635 66 31</p>
-          <p class="institution"><a href="mailto:claudia.stenger-gysling@uzh.ch"><i class="fas fa-envelope"></i></a></p>
+          <p class="institution">
+            <a href="#" onclick="u='claudia.stenger-gysling'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">
+              <i class="fas fa-envelope"></i>
+             </a>
+          </p>
         </div>
       </li>
     </ul>

--- a/content/opportunity/masters-students/index.md
+++ b/content/opportunity/masters-students/index.md
@@ -27,4 +27,4 @@ The student should have basic experience with Unix systems and some experience w
 The student will use genome sequencing data in order to discover novel structural variants in various cancer types (melanoma,   colorectal carcinoma, lung cancer, etc.). The clinical significance of the novel and already known structural variants will also be evaluated using genome annotations.
 The student should have basic experience with Unix systems and some experience with at least one scripting language (e.g. Python). Prior experience with genomics software (mappers, samtools or variant callers) is an advantage. 
 
-Applications can be done by sending a CV to this [e-mail](mailto:michael.krauthammer@uzh.ch) along with a short description of the student's motivation to join our lab.
+Applications can be done by sending a CV to this <a href="#" onclick="u='michael.krauthammer'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">e-mail</a> along with a short description of the student's motivation to join our lab.

--- a/content/opportunity/postdoc-ml-healthcare/index.md
+++ b/content/opportunity/postdoc-ml-healthcare/index.md
@@ -45,7 +45,7 @@ http://www.pa.uzh.ch/en/Willkommen-an-der-UZH.html)).
 ## Application
 
 Applicants should submit the following documents (preferably in a single PDF) to
-michael.krauthammer@uzh.ch with subject heading “Postdoc (Machine Learning in
+<a href="#" onclick="u='michael.krauthammer'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Prof. Michael Krauthammer</a> with subject heading “Postdoc (Machine Learning in
 Healthcare)”:
 
 - CV with list of publications

--- a/layouts/partials/social_links.html
+++ b/layouts/partials/social_links.html
@@ -14,7 +14,7 @@
       {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
     {{ end }}
     <li>
-      {{ if .icon = "envelope" }}
+      {{ if eq .icon "envelope" }}
         <a href="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email</a>
       {{ else }}
         <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>

--- a/layouts/partials/social_links.html
+++ b/layouts/partials/social_links.html
@@ -14,7 +14,7 @@
       {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
     {{ end }}
     <li>
-      {{ if $icon == 'envelope' }}
+      {{ if $icon = 'envelope' }}
         <a href="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email</a>
       {{ else }}
         <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>

--- a/layouts/partials/social_links.html
+++ b/layouts/partials/social_links.html
@@ -16,7 +16,7 @@
     <li>
       <!--LKK ADDED THIS TO PROTECT EMAIL ADDRESSES FROM SCRAPING-->
       {{ if eq .icon "envelope" }}
-        <a href="#" onclick="u={{ $link | safeURL }}; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">
+        <a href="#" onclick="u={{ $link }}; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">
       {{ else }}
         <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>
       {{ end }}

--- a/layouts/partials/social_links.html
+++ b/layouts/partials/social_links.html
@@ -1,0 +1,27 @@
+<ul class="network-icon" aria-hidden="true">
+  {{ range .Params.social }}
+    {{ $pack := or .icon_pack "fas" }}
+    {{ $pack_prefix := $pack }}
+    {{ if in (slice "fab" "fas" "far" "fal") $pack }}
+      {{ $pack_prefix = "fa" }}
+    {{ end }}
+    {{ $link := .link }}
+    {{ $scheme := (urls.Parse $link).Scheme }}
+    {{ $target := "" }}
+    {{ if not $scheme }}
+      {{ $link = .link | relLangURL }}
+    {{ else if in (slice "http" "https") $scheme }}
+      {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+    {{ end }}
+    <li>
+      {{ if $icon == 'envelope' }}
+        <a href="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email</a>
+      {{ else }}
+        <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>
+      {{ end }}
+
+        <i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }}"></i>
+      </a>
+    </li>
+  {{end}}
+</ul>

--- a/layouts/partials/social_links.html
+++ b/layouts/partials/social_links.html
@@ -16,7 +16,7 @@
     <li>
       <!--LKK ADDED THIS TO PROTECT EMAIL ADDRESSES FROM SCRAPING-->
       {{ if eq .icon "envelope" }}
-        <a href="#" onclick="u={{ $link }}; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">
+        <a href="#" onclick="u={{ .link }}; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">
       {{ else }}
         <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>
       {{ end }}

--- a/layouts/partials/social_links.html
+++ b/layouts/partials/social_links.html
@@ -14,8 +14,9 @@
       {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
     {{ end }}
     <li>
+      <!--LKK ADDED THIS TO PROTECT EMAIL ADDRESSES FROM SCRAPING-->
       {{ if eq .icon "envelope" }}
-        <a href="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email</a>
+        <a href="#" onclick="u={{ $link | safeURL }}; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">
       {{ else }}
         <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>
       {{ end }}

--- a/layouts/partials/social_links.html
+++ b/layouts/partials/social_links.html
@@ -14,7 +14,7 @@
       {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
     {{ end }}
     <li>
-      {{ if $icon = "envelope" }}
+      {{ if .icon = "envelope" }}
         <a href="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email</a>
       {{ else }}
         <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>

--- a/layouts/partials/social_links.html
+++ b/layouts/partials/social_links.html
@@ -14,7 +14,7 @@
       {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
     {{ end }}
     <li>
-      {{ if $icon = 'envelope' }}
+      {{ if $icon = "envelope" }}
         <a href="#" onclick="u='laura.kinkead'; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">Send email</a>
       {{ else }}
         <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -1,0 +1,115 @@
+{{ $ := .root }}
+{{ $page := .page }}
+
+{{ $author := "" }}
+{{ if .author }}
+  {{ $author = .author }}
+{{ else }}
+  {{ $author = $page.Params.author }}
+{{end}}
+
+{{ $person_page_path := (printf "/authors/%s" (anchorize $author)) }}
+{{ $person_page := site.GetPage $person_page_path }}
+{{ if not $person_page }}
+  {{ errorf "Could not find an author page at `%s`. Please check the value of `author` in your About widget and create an associated author page if one does not already exist. See https://sourcethemes.com/academic/docs/page-builder/#about " $person_page_path }}
+{{end}}
+{{ $person := $person_page.Params }}
+{{ $avatar := ($person_page.Resources.ByType "image").GetMatch "*avatar*" }}
+{{ $avatar_shape := site.Params.avatar.shape | default "circle" }}
+
+<!-- About widget -->
+<div class="row">
+  <div class="col-12 col-lg-4">
+    <div id="profile">
+
+      {{ if site.Params.avatar.gravatar }}
+      <img class="avatar {{if eq $avatar_shape "square"}}avatar-square{{else}}avatar-circle{{end}}" src="https://s.gravatar.com/avatar/{{ md5 $person.email }}?s=270')" alt="Avatar">
+      {{ else if $avatar }}
+      {{ $avatar_image := $avatar.Fill "270x270 Center" }}
+      <img class="avatar {{if eq $avatar_shape "square"}}avatar-square{{else}}avatar-circle{{end}}" src="{{ $avatar_image.RelPermalink }}" alt="Avatar">
+      {{ end }}
+
+      <div class="portrait-title">
+        <h2>{{ $person.name }}</h2>
+        {{ with $person.role }}<h3>{{ . | markdownify | emojify }}</h3>{{ end }}
+
+        {{ range $person.organizations }}
+        <h3>
+          {{ with .url }}<a href="{{ . }}" target="_blank" rel="noopener">{{ end }}
+          <span>{{ .name }}</span>
+          {{ if .url }}</a>{{ end }}
+        </h3>
+        {{ end }}
+      </div>
+
+      <ul class="network-icon" aria-hidden="true">
+        {{ range $person.social }}
+        {{ $pack := or .icon_pack "fas" }}
+        {{ $pack_prefix := $pack }}
+        {{ if in (slice "fab" "fas" "far" "fal") $pack }}
+          {{ $pack_prefix = "fa" }}
+        {{ end }}
+        {{ $link := .link }}
+        {{ $scheme := (urls.Parse $link).Scheme }}
+        {{ $target := "" }}
+        {{ if not $scheme }}
+          {{ $link = .link | relLangURL }}
+        {{ else if in (slice "http" "https") $scheme }}
+          {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+        {{ end }}
+        <li>
+          <!--LKK ADDED THIS TO PROTECT EMAIL ADDRESSES FROM SCRAPING-->
+          {{ if eq .icon "envelope" }}
+            <a href="#" onclick="u={{ $link }}; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">
+          {{ else }}
+            <a href="{{ $link }}" {{ $target | safeHTMLAttr }}>
+          {{ end }}
+
+            <i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }}"></i>
+          </a>
+        </li>
+        {{ end }}
+      </ul>
+
+    </div>
+  </div>
+  <div class="col-12 col-lg-8">
+
+    {{/* Only display widget title in explicit instances of about widget, not in author pages. */}}
+    {{ if and $page.Params.widget $page.Title }}<h1>{{ $page.Title | markdownify | emojify }}</h1>{{ end }}
+
+    {{ $person_page.Content }}
+
+    <div class="row">
+
+      {{ with $person.interests }}
+      <div class="col-md-5">
+        <h3>{{ i18n "interests" | markdownify }}</h3>
+        <ul class="ul-interests">
+          {{ range . }}
+          <li>{{ . | markdownify | emojify }}</li>
+          {{ end }}
+        </ul>
+      </div>
+      {{ end }}
+
+      {{ with $person.education }}
+      <div class="col-md-7">
+        <h3>{{ i18n "education" | markdownify }}</h3>
+        <ul class="ul-edu fa-ul">
+          {{ range .courses }}
+          <li>
+            <i class="fa-li fas fa-graduation-cap"></i>
+            <div class="description">
+              <p class="course">{{ .course }}{{ with .year }}, {{ . }}{{ end }}</p>
+              <p class="institution">{{ .institution }}</p>
+            </div>
+          </li>
+          {{ end }}
+        </ul>
+      </div>
+      {{ end }}
+
+    </div>
+  </div>
+</div>

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -60,7 +60,7 @@
         <li>
           <!--LKK ADDED THIS TO PROTECT EMAIL ADDRESSES FROM SCRAPING-->
           {{ if eq .icon "envelope" }}
-            <a href="#" onclick="u={{ $link }}; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">
+            <a href="#" onclick="u={{ .link }}; d='uzh.ch'; prompt('Copy address to clipboard',u+'@'+d); return false">
           {{ else }}
             <a href="{{ $link }}" {{ $target | safeHTMLAttr }}>
           {{ end }}


### PR DESCRIPTION
Protected emails from scraping by only showing them in an `onclick` text box, as done in the old website.

Edited the following files to protect emails in various places around the site:
* `layouts/partials/widgets/about.html` for the email buttons on peoples' author pages
* `layouts/partials/social_links.html` for the email buttons below their names on pages they've written
* `content/home/contact.html` for the email buttons below Michael's and Claudia's contact info in the Contact section at the bottom of the main page. 
