### PR TITLE
Add filter to posts

### DIFF
--- a/content/home/posts.md
+++ b/content/home/posts.md
@@ -34,17 +34,17 @@ subtitle = ""
   filter_default = 0
 
   # LK: I don't understand why this doesn't work
-  #[[content.filter_button]]
-  #  name = "All"
-  #  tag = "*"
+  [[content.filter_button]]
+    name = "All"
+    tag = "*"
 
-  #[[content.filter_button]]
-  #  name = "Talks"
-  #  tag = "Talks"
+  [[content.filter_button]]
+    name = "Talks"
+    tag = "Talks"
 
-  #[[content.filter_button]]
-  #  name = "Fun"
-  #  tag = "Fun"
+  [[content.filter_button]]
+    name = "Fun"
+    tag = "Fun"
 
 [design]
   # Toggle between the various page layout types.

--- a/content/home/posts.md
+++ b/content/home/posts.md
@@ -29,23 +29,29 @@ subtitle = ""
   #   category = ""
   #   publication_type = ""
   #   exclude_featured = false
-
+  [content.filters]
+    tag = "Tasks"
+    category = "tasks"
+    publication_type = ""
+    exclude_featured = false
+    exclude_past = false
+    exclude_future = false
 
   # Default filter index (e.g. 0 corresponds to the first `[[filter_button]]` instance below).
   filter_default = 1
 
   # LK: I don't understand why this doesn't work
-  [[content.filter_button]]
-    name = "All"
-    tag = "*"
+  #[[content.filter_button]]
+  #  name = "All"
+  #  tag = "*"
 
-  [[content.filter_button]]
-    name = "Talks"
-    tag = "Talks"
+  #[[content.filter_button]]
+  #  name = "Talks"
+  #  tag = "Talks"
 
-  [[content.filter_button]]
-    name = "Fun"
-    tag = "Fun"
+  #[[content.filter_button]]
+  #  name = "Fun"
+  #  tag = "Fun"
 
 [design]
   # Toggle between the various page layout types.

--- a/content/home/posts.md
+++ b/content/home/posts.md
@@ -2,7 +2,7 @@
 # A Recent Blog Posts section created with the Pages widget.
 # This section displays recent blog posts from `content/post/`.
 
-widget = "pages"  # See https://sourcethemes.com/academic/docs/page-builder/
+widget = "portfolio"  # See https://sourcethemes.com/academic/docs/page-builder/
 headless = true  # This file represents a page section.
 active = true  # Activate this widget? true/false
 weight = 65  # Order that this section will appear.
@@ -29,16 +29,9 @@ subtitle = ""
   #   category = ""
   #   publication_type = ""
   #   exclude_featured = false
-  [content.filter]
-    tag = "Talks"
-    category = "talks"
-    publication_type = ""
-    exclude_featured = false
-    exclude_past = false
-    exclude_future = false
 
   # Default filter index (e.g. 0 corresponds to the first `[[filter_button]]` instance below).
-  filter_default = 1
+  filter_default = 0
 
   # LK: I don't understand why this doesn't work
   #[[content.filter_button]]

--- a/content/home/posts.md
+++ b/content/home/posts.md
@@ -35,8 +35,12 @@ subtitle = ""
 
   # LK: I don't understand why this doesn't work
   [[content.filter_button]]
-    name = "All"
-    tag = "*"
+    name = "Recent"
+    tag = "Recent"
+
+[[content.filter_button]]
+    name = "Research"
+    tag = "Research"
 
   [[content.filter_button]]
     name = "Talks"

--- a/content/home/posts.md
+++ b/content/home/posts.md
@@ -30,8 +30,8 @@ subtitle = ""
   #   publication_type = ""
   #   exclude_featured = false
   [content.filter]
-    tag = "Tasks"
-    category = "tasks"
+    tag = "Talks"
+    category = "talks"
     publication_type = ""
     exclude_featured = false
     exclude_past = false

--- a/content/home/posts.md
+++ b/content/home/posts.md
@@ -30,6 +30,10 @@ subtitle = ""
   #   publication_type = ""
   #   exclude_featured = false
 
+
+  # Default filter index (e.g. 0 corresponds to the first `[[filter_button]]` instance below).
+  filter_default = 1
+
   # LK: I don't understand why this doesn't work
   [[content.filter_button]]
     name = "All"

--- a/content/home/posts.md
+++ b/content/home/posts.md
@@ -29,7 +29,7 @@ subtitle = ""
   #   category = ""
   #   publication_type = ""
   #   exclude_featured = false
-  [content.filters]
+  [content.filter]
     tag = "Tasks"
     category = "tasks"
     publication_type = ""

--- a/content/post/about-reproducibility/index.md
+++ b/content/post/about-reproducibility/index.md
@@ -7,6 +7,7 @@ date: 2020-09-22
 tags: 
 - Reproducibility
 - Data Science
+- Research
 categories:
 - Research
 image:

--- a/content/post/adlisberg-hike/index.md
+++ b/content/post/adlisberg-hike/index.md
@@ -6,6 +6,7 @@ authors:
 date: 2021-05-01
 tags: 
 - Fun
+- Recent
 categories:
 - Fun
 image:

--- a/content/post/blog_book-review_Causality-Probability-and-Medicine-by-Gillies/index.md
+++ b/content/post/blog_book-review_Causality-Probability-and-Medicine-by-Gillies/index.md
@@ -6,6 +6,7 @@ date: 2020-04-29
 tags: 
 - Blog
 - Book Review
+- Fun
 image:
   placement: 1
   focal_point: ""

--- a/content/post/datatc-intro/index.md
+++ b/content/post/datatc-intro/index.md
@@ -7,6 +7,8 @@ date: 2021-06-22
 tags: 
 - Reproducibility
 - Data Science
+- Recent
+- Research
 categories:
 - Research
 image:

--- a/content/post/dqbm-opening/index.md
+++ b/content/post/dqbm-opening/index.md
@@ -4,9 +4,9 @@ authors:
 - nicoperez
 date: 2020-01-27
 tags: 
-- fun
+- Fun
 categories:
-- fun
+- Fun
 image:
   placement: 1
   caption: 'Members of the department of Quantitative Biomedicine at UZH.'

--- a/content/post/genomics/index.md
+++ b/content/post/genomics/index.md
@@ -6,6 +6,8 @@ authors:
 date: 2021-01-21
 tags: 
 - Genomics
+- Recent
+- Research
 categories:
 - Genomics
 image:

--- a/content/post/retrotransposons/index.md
+++ b/content/post/retrotransposons/index.md
@@ -5,6 +5,7 @@ authors:
 - zsoltbalazs
 date: 2020-02-17
 tags: 
+- Research
 - Genetics
 categories:
 - Genetics


### PR DESCRIPTION
Changed the widget type to be portfolio so that filters for posts would appear. Means there's no separate 'posts' page and we can't show all posts at once (well, we can - but it gets to quite a long list), so I added in a recent filter to show just a select few posts. 